### PR TITLE
Support #68, #79, #80, #83 and fixes #60, #78

### DIFF
--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -944,5 +944,13 @@
             <loadingArea offset="-0.1 1.73 -1.46" width="2.6" height="2.5" length="9"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_RollandRPLCH/RP9006LCH.xml" modHubId="240058">  
+			<loadingArea offset="0 1.1 0.5" width="2.5" height="2.7" length="9" baleHeight="3.2"/>
+			<options isBaleTrailer="true" enableSideLoading="true"/>
+		</vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_RollandRPLCH/RP10006LCH.xml" modHubId="240058">  
+			<loadingArea offset="0 1.1 0" width="2.5" height="2.7" length="10" baleHeight="3.2"/>
+			<options isBaleTrailer="true" enableSideLoading="true"/>
+		</vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -167,7 +167,7 @@
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_PongePack/SPEX_7519/SPEX.xml" modHubId="229558">
             <loadingArea offset="0 0.978 -2.915" width="2.3" height="1.70" length="5.743" baleHeight="2.64"/>
-			<options enableRearLoading="true" enableSideLoading="true"/>
+            <options enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_RollandPack/LSEL10006/LSEL10006_Square.xml" modHubId="225090">
             <loadingArea offset="0 1.137 -0.18" width="2.5" height="1.90" length="10.0" baleHeight="3.00"/>
@@ -183,7 +183,7 @@
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_PerardPack/rpe26/rpe26.xml" modHubId="241424">
             <loadingArea offset="0 1.207 0" width="2.235" height="1.70" length="6.848" baleHeight="3.00"/>
-			<options enableRearLoading="true" enableSideLoading="true"/>
+            <options enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_ThievinPack/mistral_pl_260_118/mistral_pl_260_118.xml" useConfigName="vehicleType" selectedConfigs="1" modHubId="257556">
             <loadingArea offset="0 1.13 -0.340" width="2.40" height="1.90" length="11.75" baleHeight="3.00"/>
@@ -261,7 +261,7 @@
             <loadingArea offset="0 1.00 -1.78" width="2.70" height="2.00" length="5.43" baleHeight="2.70"/>
             <options isBaleTrailer="true" enableSideLoading="true"/>
         </vehicleConfiguration>
-		    <vehicleConfiguration configFileName="FS22_lizardTrailerPack/lizardD83.xml" selectedConfigs="7,8" modHubId="226713">
+        <vehicleConfiguration configFileName="FS22_lizardTrailerPack/lizardD83.xml" selectedConfigs="7,8" modHubId="226713">
             <loadingArea offset="0 1.50 0" width="2.35" height="2.5" length="6.2"/>
             <options enableSideLoading="true" />
         </vehicleConfiguration>
@@ -275,7 +275,7 @@
         <vehicleConfiguration configFileName="FS22_lizardTrailerPack/lizardD616.xml" selectedConfigs="7,8" modHubId="226713">
             <loadingArea offset="0 1.52 0.48" width="2.35" height="1.70" length="7.25" baleHeight="2.50"/>
             <options enableSideLoading="true"/>
-        </vehicleConfiguration>			
+        </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_lizardTrailerPack/lizardD616K.xml" selectedConfigs="1" modHubId="226713">
             <loadingArea offset="0 1.70 0.48" width="2.35" height="1.70" length="7.25" baleHeight="2.50"/>
         </vehicleConfiguration>
@@ -554,7 +554,7 @@
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_Kesla_144ND/nd122.xml" modHubId="232093">
             <loadingArea offset="0 0.888 -0.30" width="2.20" height="1.7" length="4.2"/>
-			<options isLogTrailer="true"/>
+            <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_LizardLT679SmallLogTrailer/SmallLogTrailer.xml" modHubId="245565">  
             <loadingArea offset="0 1.35 0.57" width="2.85" height="2.10" length="6.3"/>
@@ -574,11 +574,11 @@
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_Longbunktimber/longbunk.xml" modHubId="254475">
             <loadingArea offset="0 1.666 -0.05" width="2.40" height="2.2" length="12.3"/>
-			<options isLogTrailer="true"/>
+            <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_TimberPack/xml/TimberSemi.xml" modHubId="250084">
             <loadingArea offset="0 1.666 -0.05" width="2.40" height="2.50" length="12.3"/>
-			<options isLogTrailer="true"/>
+            <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_TimberPack/xml/Trailer.xml" modHubId="250084">  
             <loadingArea offset="0 1.67 -0.20" width="2.35" height="2.50" length="7.0"/>
@@ -590,11 +590,11 @@
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_TLX_X52_Logger/x52_logger.xml" modHubId="248615">
             <loadingArea offset="0 1.40 -0.50" width="2.15" height="2.20" length="14.5"/>
-			<options isLogTrailer="true"/>
+            <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_TLX_X52_Logger/x52_logger_trax.xml" modHubId="248615">
             <loadingArea offset="0 1.40 -0.50" width="2.15" height="2.20" length="14.5"/>
-			<options isLogTrailer="true"/>
+            <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_Lizard_wood_trailer/lizard.xml" modHubId="245659">  
             <loadingArea offset="0 0.85 -2.55" width="1.80" height="1.25" length="5"/>
@@ -753,11 +753,11 @@
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_lizardLogger/lizardLogger.xml" modHubId="230269">
             <loadingArea offset="-0.13 1.86 -0.20" width="2.40" height="2.20" length="13"/>
-			<options isLogTrailer="true"/>
+            <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_PlantationTrailer/plantationtrailer.xml" modHubId="242524">
             <loadingArea offset="0 1.60 -0.15" width="2.35" height="2.75" length="13"/>
-			<options isLogTrailer="true"/>
+            <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_LizardTP10M/carretaMaquina.xml" modHubId="249931">
             <loadingArea offset="0 1.13 0.25" width="3.95" height="2.35" length="7.50" baleHeight="3.00"/>
@@ -928,63 +928,63 @@
             <loadingArea offset="0.000 1.11 -1.65" width="2.0" height="1.75" length="3.0" baleHeight="2.75"/>
             <options enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" useConfigName="design" selectedConfigs="1" modHubId="264240">  
+        <vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" useConfigName="design" selectedConfigs="1" modHubId="264240">  
             <loadingArea offset="-0.1 1.49 0.03" width="2.6" height="2.8" length="12.6" baleHeight="2.8"/>
             <options enableSideLoading="true"/>
         </vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" useConfigName="design" selectedConfigs="2" modHubId="264240">  
+        <vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" useConfigName="design" selectedConfigs="2" modHubId="264240">  
             <loadingArea offset="-0.1 1.49 0.03" width="2.6" height="2.7" length="12.6"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" useConfigName="design" selectedConfigs="1" modHubId="264240">  
+        <vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" useConfigName="design" selectedConfigs="1" modHubId="264240">  
             <loadingArea offset="-0.1 1.73 -1.46" width="2.6" height="2.8" length="9" baleHeight="2.8"/>
             <options enableSideLoading="true"/>
         </vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" useConfigName="design" selectedConfigs="2" modHubId="264240">  
+        <vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" useConfigName="design" selectedConfigs="2" modHubId="264240">  
             <loadingArea offset="-0.1 1.73 -1.46" width="2.6" height="2.5" length="9"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_RollandRPLCH/RP9006LCH.xml" modHubId="240058">  
-			<loadingArea offset="0 1.1 0.5" width="2.5" height="2.7" length="9" baleHeight="3.2"/>
-			<options isBaleTrailer="true" enableSideLoading="true"/>
-		</vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_RollandRPLCH/RP10006LCH.xml" modHubId="240058">  
-			<loadingArea offset="0 1.1 0" width="2.5" height="2.7" length="10" baleHeight="3.2"/>
-			<options isBaleTrailer="true" enableSideLoading="true"/>
-		</vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AW362_CaboverR/bau.xml" modHubId="250565">  
+        <vehicleConfiguration configFileName="FS22_RollandRPLCH/RP9006LCH.xml" modHubId="240058">  
+            <loadingArea offset="0 1.1 0.5" width="2.5" height="2.7" length="9" baleHeight="3.2"/>
+            <options isBaleTrailer="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_RollandRPLCH/RP10006LCH.xml" modHubId="240058">  
+            <loadingArea offset="0 1.1 0" width="2.5" height="2.7" length="10" baleHeight="3.2"/>
+            <options isBaleTrailer="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/bau.xml" modHubId="250565">  
             <loadingArea offset="0 1.27 -1.92" width="2.4" height="2.8" length="7.6"/>
             <options isBoxTrailer="true" enableRearLoading="true"/>
         </vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AW362_CaboverR/bauDD60.xml" modHubId="250565">  
+        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/bauDD60.xml" modHubId="250565">  
             <loadingArea offset="0 1.27 -1.92" width="2.4" height="2.8" length="7.6"/>
             <options isBoxTrailer="true" enableRearLoading="true"/>
         </vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AW362_CaboverR/prancha.xml" modHubId="250565">  
+        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/prancha.xml" modHubId="250565">  
             <loadingArea offset="0 1.41 -2.18" width="2.36" height="2.4" length="7.55" baleHeight="3.2" noLoadingIfUnfolded="true"/>
             <options isBaleTrailer="true" enableSideLoading="true" enableRearLoading="true"/>
         </vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AW362_CaboverR/pranchaDD60.xml" modHubId="250565">  
+        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/pranchaDD60.xml" modHubId="250565">  
             <loadingArea offset="0 1.41 -2.18" width="2.36" height="2.4" length="7.55" baleHeight="3.2" noLoadingIfUnfolded="true"/>
             <options isBaleTrailer="true" enableSideLoading="true" enableRearLoading="true"/>
         </vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AW362_CaboverR/madeira.xml" modHubId="250565">  
+        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/madeira.xml" modHubId="250565">  
             <loadingArea offset="0 1.22 -2.03" width="2.35" height="2.3" length="6.8"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AW362_CaboverR/madeiraDD60.xml" modHubId="250565">  
+        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/madeiraDD60.xml" modHubId="250565">  
             <loadingArea offset="0 1.22 -2.03" width="2.35" height="2.3" length="6.8"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="1" modHubId="243774">  
-			<loadingArea offset="0 2.62 0.46" width="2.55" height="2" length="6.3" baleHeight="2.8"/>
-			<options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
-		</vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="2" modHubId="243774">  
-			<loadingArea offset="0 2.62 0.46" width="2.55" height="2" length="6.3" baleHeight="2.8"/>
-			<options enableRearLoading="true" enableSideLoading="true"/>
+        <vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="1" modHubId="243774">  
+            <loadingArea offset="0 2.62 0.46" width="2.55" height="2" length="6.3" baleHeight="2.8"/>
+            <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="4" modHubId="243774">  
+        <vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="2" modHubId="243774">  
+            <loadingArea offset="0 2.62 0.46" width="2.55" height="2" length="6.3" baleHeight="2.8"/>
+            <options enableRearLoading="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="4" modHubId="243774">  
             <loadingArea offset="0 2.62 0.35" width="2.35" height="1.4" length="6.5"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -996,5 +996,13 @@
             <loadingArea offset="0 1.84 -1.55" width="2.25" height="2.55" length="6.5"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_ITRTwo/ITRTwo.xml" selectedConfigs="1" modHubId="259967">
+            <loadingArea offset="0.000 0.334 0.132" width="2.5" height="2.80" length="7.35"/>
+            <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_ITRTwo/ITRTwo.xml" selectedConfigs="2" modHubId="259967">
+            <loadingArea offset="0.000 0.5 0.15" width="2.35" height="2.3" length="7.1"/>
+            <options isLogTrailer="true"/>
+        </vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -952,5 +952,29 @@
 			<loadingArea offset="0 1.1 0" width="2.5" height="2.7" length="10" baleHeight="3.2"/>
 			<options isBaleTrailer="true" enableSideLoading="true"/>
 		</vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_AW362_CaboverR/bau.xml" modHubId="250565">  
+            <loadingArea offset="0 1.27 -1.92" width="2.4" height="2.8" length="7.6"/>
+            <options isBoxTrailer="true" enableRearLoading="true"/>
+        </vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_AW362_CaboverR/bauDD60.xml" modHubId="250565">  
+            <loadingArea offset="0 1.27 -1.92" width="2.4" height="2.8" length="7.6"/>
+            <options isBoxTrailer="true" enableRearLoading="true"/>
+        </vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_AW362_CaboverR/prancha.xml" modHubId="250565">  
+            <loadingArea offset="0 1.41 -2.18" width="2.36" height="2.4" length="7.55" baleHeight="3.2" noLoadingIfUnfolded="true"/>
+            <options isBaleTrailer="true" enableSideLoading="true" enableRearLoading="true"/>
+        </vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_AW362_CaboverR/pranchaDD60.xml" modHubId="250565">  
+            <loadingArea offset="0 1.41 -2.18" width="2.36" height="2.4" length="7.55" baleHeight="3.2" noLoadingIfUnfolded="true"/>
+            <options isBaleTrailer="true" enableSideLoading="true" enableRearLoading="true"/>
+        </vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_AW362_CaboverR/madeira.xml" modHubId="250565">  
+            <loadingArea offset="0 1.22 -2.03" width="2.35" height="2.3" length="6.8"/>
+            <options isLogTrailer="true"/>
+        </vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_AW362_CaboverR/madeiraDD60.xml" modHubId="250565">  
+            <loadingArea offset="0 1.22 -2.03" width="2.35" height="2.3" length="6.8"/>
+            <options isLogTrailer="true"/>
+        </vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -113,9 +113,13 @@
         <vehicleConfiguration configFileName="FS22_allPurposeTool/all-purpose-tool.xml" modHubId="227935">
             <loadingArea offset="0 0.15 0.80" width="3.50" height="2.25" length="1.90"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_Bailey_Bale_Pallet_Trailer/BPTrailer.xml" modHubId="228030">
-            <loadingArea offset="0 1.08 -0.65" width="2.55" height="1.70" length="7.0" baleHeight="2.50"/>
+        <vehicleConfiguration configFileName="FS22_Bailey_Bale_Pallet_Trailer/BPTrailer.xml" selectedConfigs="1,3" modHubId="228030">
+            <loadingArea offset="0 1.07 -0.72" width="2.65" height="2.4" length="6.75" baleHeight="3.20"/>
             <options isBaleTrailer="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_Bailey_Bale_Pallet_Trailer/BPTrailer.xml" selectedConfigs="2,4" modHubId="228030">
+            <loadingArea offset="0 1.07 -0.89" width="2.65" height="2.4" length="7.1" baleHeight="3.20"/>
+            <options isBaleTrailer="true" enableSideLoading="true" enableRearLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_Brantner_DD_24073/dd24073.xml" selectedConfigs="1,4,5" modHubId="227421">
             <loadingArea offset="0 1.43 -0.70" width="2.45" height="1.70" length="7.20" baleHeight="2.50"/>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -1008,5 +1008,13 @@
             <loadingArea offset="0.000 0.5 0.15" width="2.35" height="2.3" length="7.1"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_marshallBC32/marshallBC32.xml" selectedConfigs="1" modHubId="235656">
+            <loadingArea offset="0 1.35 -0.18" width="2.45" height="2.6" length="9.5" baleHeight="3.8"/>
+            <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_marshallBC32/marshallBC32.xml" selectedConfigs="2" modHubId="235656">
+            <loadingArea offset="0 1.35 -0.18" width="2.45" height="2.6" length="9.5" baleHeight="3.8"/>
+            <options isBaleTrailer="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -1016,5 +1016,17 @@
             <loadingArea offset="0 1.35 -0.18" width="2.45" height="2.6" length="9.5" baleHeight="3.8"/>
             <options isBaleTrailer="true" enableSideLoading="true"/>
         </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_JunkkariJ16_J18/j16jl.xml" selectedConfigs="1" modHubId="249628">
+            <loadingArea offset="0 0.854 -0.93" width="2.65" height="2.6" length="6.3" baleHeight="3.8"/>
+            <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_JunkkariJ16_J18/j16jl.xml" selectedConfigs="2" modHubId="249628">
+            <loadingArea offset="0 0.854 -1.35" width="2.53" height="2.6" length="7.4" baleHeight="3.8"/>
+            <options isBaleTrailer="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_JunkkariJ16_J18/j16jl.xml" selectedConfigs="3" modHubId="249628">
+            <loadingArea offset="0 0.854 -0.72" width="2.65" height="2.6" length="5.8" baleHeight="3.8" noLoadingIfFolded="true"/>
+            <options isBaleTrailer="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -320,9 +320,10 @@
             <options enableSideLoading="true" enableRearLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_lizard_sp03_crossplay/sp03.xml" modHubId="243958">
-            <loadingArea offset="0 1.00 -2.10" width="2.30" height="1.70" length="9.6" baleHeight="2.50"/>
-            <options enableSideLoading="true" enableRearLoading="true"/>
-        </vehicleConfiguration> <!-- needs second loading zone -->
+            <loadingArea offset="0 1.32 4.67" width="2.65" height="2.6" length="3.7" baleHeight="3.80"/>
+            <loadingArea offset="0 0.897 -2.1" width="2.65" height="2.6" length="9.8" baleHeight="3.80"/>
+            <options isBaleTrailer="true" enableSideLoading="true" enableRearLoading="true"/>
+        </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_camara_sp03/sp03.xml" modHubId="243957">
             <loadingArea offset="0 1.00 -2.10" width="2.30" height="1.70" length="9.6" baleHeight="2.50"/>
             <options enableSideLoading="true" enableRearLoading="true"/>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -1038,5 +1038,9 @@
             <loadingArea offset="0 1.23 -2.12" width="2.5" height="2.6" length="8.5" baleHeight="3.8"/>
             <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_lizard_rp03/rp03.xml" modHubId="264436">
+            <loadingArea offset="0 0.897 -1.08" width="2.5" height="2.6" length="7.8" baleHeight="3.8"/>
+            <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -1028,5 +1028,9 @@
             <loadingArea offset="0 0.854 -0.72" width="2.65" height="2.6" length="5.8" baleHeight="3.8" noLoadingIfFolded="true"/>
             <options isBaleTrailer="true" enableSideLoading="true"/>
         </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_Old20FootBaleTrailer/baleTrailer20Foot.xml" modHubId="267221">
+            <loadingArea offset="0 1.084 -0.1" width="2.65" height="2.6" length="6.5" baleHeight="3.8"/>
+            <options isBaleTrailer="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -325,9 +325,10 @@
             <options isBaleTrailer="true" enableSideLoading="true" enableRearLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_camara_sp03/sp03.xml" modHubId="243957">
-            <loadingArea offset="0 1.00 -2.10" width="2.30" height="1.70" length="9.6" baleHeight="2.50"/>
-            <options enableSideLoading="true" enableRearLoading="true"/>
-        </vehicleConfiguration> <!-- needs second loading zone -->
+            <loadingArea offset="0 1.32 4.67" width="2.65" height="2.6" length="3.7" baleHeight="3.80"/>
+            <loadingArea offset="0 0.897 -2.1" width="2.65" height="2.6" length="9.8" baleHeight="3.80"/>
+            <options isBaleTrailer="true" enableSideLoading="true" enableRearLoading="true"/>
+        </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_LizardTrailer/LizardTrailer_Bales.xml" selectedConfigs="1" modHubId="229433">
             <loadingArea offset="0 1.65 -0.40" width="2.40" height="1.70" length="13.45" baleHeight="2.50"/>
             <options enableSideLoading="true"/>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -976,5 +976,17 @@
             <loadingArea offset="0 1.22 -2.03" width="2.35" height="2.3" length="6.8"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="1" modHubId="243774">  
+			<loadingArea offset="0 2.62 0.46" width="2.55" height="2" length="6.3" baleHeight="2.8"/>
+			<options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
+		</vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="2" modHubId="243774">  
+			<loadingArea offset="0 2.62 0.46" width="2.55" height="2" length="6.3" baleHeight="2.8"/>
+			<options enableRearLoading="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="4" modHubId="243774">  
+            <loadingArea offset="0 2.62 0.35" width="2.35" height="1.4" length="6.5"/>
+            <options isLogTrailer="true"/>
+        </vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -1034,5 +1034,9 @@
             <loadingArea offset="0 1.084 -0.1" width="2.65" height="2.6" length="6.5" baleHeight="3.8"/>
             <options isBaleTrailer="true" enableSideLoading="true"/>
         </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_manTGX_26640_strawbale/tgx26640.xml" modHubId="264434">
+            <loadingArea offset="0 1.23 -2.12" width="2.5" height="2.6" length="8.5" baleHeight="3.8"/>
+            <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -928,5 +928,21 @@
             <loadingArea offset="0.000 1.11 -1.65" width="2.0" height="1.75" length="3.0" baleHeight="2.75"/>
             <options enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" useConfigName="design" selectedConfigs="1" modHubId="264240">  
+            <loadingArea offset="-0.1 1.49 0.03" width="2.6" height="2.8" length="12.6" baleHeight="2.8"/>
+            <options enableSideLoading="true"/>
+        </vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" useConfigName="design" selectedConfigs="2" modHubId="264240">  
+            <loadingArea offset="-0.1 1.49 0.03" width="2.6" height="2.7" length="12.6"/>
+            <options isLogTrailer="true"/>
+        </vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" useConfigName="design" selectedConfigs="1" modHubId="264240">  
+            <loadingArea offset="-0.1 1.73 -1.46" width="2.6" height="2.8" length="9" baleHeight="2.8"/>
+            <options enableSideLoading="true"/>
+        </vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" useConfigName="design" selectedConfigs="2" modHubId="264240">  
+            <loadingArea offset="-0.1 1.73 -1.46" width="2.6" height="2.5" length="9"/>
+            <options isLogTrailer="true"/>
+        </vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -739,16 +739,16 @@
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_Komatsu_Forwarder_Pack/forwarder855.xml" modHubId="247034">
-            <loadingArea offset="0 1.40 -3.45" width="2.70" height="0.6" length="5.0" heightAxis="AXIS_CRANE_TOOL3"/>
+            <loadingArea offset="0 1.88 -3.67" width="2.70" height="1.7" length="5.5"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_Komatsu_Forwarder_Pack/forwarder875.xml" modHubId="247034">
-            <loadingArea offset="0 1.40 -3.45" width="2.70" height="2.12" length="5.0"/>
+            <loadingArea offset="0 1.88 -3.67" width="2.70" height="1.7" length="5.5"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_Komatsu_Forwarder_Pack/forwarder875FLX.xml" modHubId="247034">
-            <loadingArea offset="0 1.40 -3.45" width="2.70" height="0.6" length="5.0" heightAxis="AXIS_CRANE_TOOL3" noLoadingIfUnfolded="true"/>
-            <loadingArea offset="0 1.40 -3.45" width="3.40" height="0.6" length="5.0" heightAxis="AXIS_CRANE_TOOL3" noLoadingIfFolded="true"/>
+            <loadingArea offset="0 1.88 -3.67" width="2.70" height="1.7" length="5.5" noLoadingIfUnfolded="true"/>
+            <loadingArea offset="0 1.88 -3.67" width="3.45" height="1.7" length="5.5" noLoadingIfFolded="true"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_lizardLogger/lizardLogger.xml" modHubId="230269">

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -934,63 +934,67 @@
             <loadingArea offset="0.000 1.11 -1.65" width="2.0" height="1.75" length="3.0" baleHeight="2.75"/>
             <options enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" useConfigName="design" selectedConfigs="1" modHubId="264240">  
-            <loadingArea offset="-0.1 1.49 0.03" width="2.6" height="2.8" length="12.6" baleHeight="2.8"/>
-            <options enableSideLoading="true"/>
+        <vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" useConfigName="design" selectedConfigs="1" modHubId="264240">
+            <loadingArea offset="-0.09 1.49 -0.1" width="2.7" height="2.5" length="12.9" baleHeight="3.8"/>
+            <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" useConfigName="design" selectedConfigs="2" modHubId="264240">  
-            <loadingArea offset="-0.1 1.49 0.03" width="2.6" height="2.7" length="12.6"/>
+        <vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" useConfigName="design" selectedConfigs="2" modHubId="264240">
+            <loadingArea offset="-0.09 1.49 -0.1" width="2.6" height="2.7" length="12.9"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" useConfigName="design" selectedConfigs="1" modHubId="264240">  
-            <loadingArea offset="-0.1 1.73 -1.46" width="2.6" height="2.8" length="9" baleHeight="2.8"/>
-            <options enableSideLoading="true"/>
+        <vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" useConfigName="design" selectedConfigs="1" modHubId="264240">
+            <loadingArea offset="-0.1 1.73 -1.58" width="2.7" height="2.5" length="9.3" baleHeight="3.8"/>
+            <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" useConfigName="design" selectedConfigs="2" modHubId="264240">  
+        <vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" useConfigName="design" selectedConfigs="2" modHubId="264240">
             <loadingArea offset="-0.1 1.73 -1.46" width="2.6" height="2.5" length="9"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_RollandRPLCH/RP9006LCH.xml" modHubId="240058">  
-            <loadingArea offset="0 1.1 0.5" width="2.5" height="2.7" length="9" baleHeight="3.2"/>
+        <vehicleConfiguration configFileName="FS22_RollandRPLCH/RP9006LCH.xml" selectedConfigs="1,2,4" modHubId="240058">
+            <loadingArea offset="0 1.082 0.3" width="2.5" height="2.6" length="9.4" baleHeight="3.8"/>
             <options isBaleTrailer="true" enableSideLoading="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_RollandRPLCH/RP10006LCH.xml" modHubId="240058">  
-            <loadingArea offset="0 1.1 0" width="2.5" height="2.7" length="10" baleHeight="3.2"/>
+        <vehicleConfiguration configFileName="FS22_RollandRPLCH/RP9006LCH.xml" selectedConfigs="3,5,6" modHubId="240058">
+            <loadingArea offset="0 1.082 0.5" width="2.5" height="2.6" length="9" baleHeight="3.8"/>
             <options isBaleTrailer="true" enableSideLoading="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/bau.xml" modHubId="250565">  
+        <vehicleConfiguration configFileName="FS22_RollandRPLCH/RP10006LCH.xml" selectedConfigs="1,2,4" modHubId="240058">
+            <loadingArea offset="0 1.082 -0.2" width="2.5" height="2.6" length="10.4" baleHeight="3.8"/>
+            <options isBaleTrailer="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_RollandRPLCH/RP10006LCH.xml" selectedConfigs="3,5,6" modHubId="240058">
+            <loadingArea offset="0 1.082 0" width="2.5" height="2.6" length="10" baleHeight="3.8"/>
+            <options isBaleTrailer="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/bau.xml" modHubId="250565">
             <loadingArea offset="0 1.27 -1.92" width="2.4" height="2.8" length="7.6"/>
             <options isBoxTrailer="true" enableRearLoading="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/bauDD60.xml" modHubId="250565">  
+        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/bauDD60.xml" modHubId="250565">
             <loadingArea offset="0 1.27 -1.92" width="2.4" height="2.8" length="7.6"/>
             <options isBoxTrailer="true" enableRearLoading="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/prancha.xml" modHubId="250565">  
+        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/prancha.xml" modHubId="250565">
             <loadingArea offset="0 1.41 -2.18" width="2.36" height="2.4" length="7.55" baleHeight="3.2" noLoadingIfUnfolded="true"/>
             <options isBaleTrailer="true" enableSideLoading="true" enableRearLoading="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/pranchaDD60.xml" modHubId="250565">  
+        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/pranchaDD60.xml" modHubId="250565">
             <loadingArea offset="0 1.41 -2.18" width="2.36" height="2.4" length="7.55" baleHeight="3.2" noLoadingIfUnfolded="true"/>
             <options isBaleTrailer="true" enableSideLoading="true" enableRearLoading="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/madeira.xml" modHubId="250565">  
+        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/madeira.xml" modHubId="250565">
             <loadingArea offset="0 1.22 -2.03" width="2.35" height="2.3" length="6.8"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/madeiraDD60.xml" modHubId="250565">  
+        <vehicleConfiguration configFileName="FS22_AW362_CaboverR/madeiraDD60.xml" modHubId="250565">
             <loadingArea offset="0 1.22 -2.03" width="2.35" height="2.3" length="6.8"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="1" modHubId="243774">  
-            <loadingArea offset="0 2.62 0.46" width="2.55" height="2" length="6.3" baleHeight="2.8"/>
+        <vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="1" modHubId="243774">
+            <loadingArea offset="0 2.62 0.46" width="2.55" height="2.6" length="6.3" baleHeight="2.8"/>
             <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="2" modHubId="243774">  
-            <loadingArea offset="0 2.62 0.46" width="2.55" height="2" length="6.3" baleHeight="2.8"/>
-            <options enableRearLoading="true" enableSideLoading="true"/>
-        </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="4" modHubId="243774">  
+        <vehicleConfiguration configFileName="FS22_LizardF600/Granel.xml" selectedConfigs="4" modHubId="243774">
             <loadingArea offset="0 2.62 0.35" width="2.35" height="1.4" length="6.5"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
@@ -1003,35 +1007,31 @@
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_ITRTwo/ITRTwo.xml" selectedConfigs="1" modHubId="259967">
-            <loadingArea offset="0.000 0.334 0.132" width="2.5" height="2.80" length="7.35"/>
+            <loadingArea offset="0 0.334 0.132" width="2.5" height="2.80" length="7.35" baleHeight="3.8"/>
             <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_ITRTwo/ITRTwo.xml" selectedConfigs="2" modHubId="259967">
-            <loadingArea offset="0.000 0.5 0.15" width="2.35" height="2.3" length="7.1"/>
+            <loadingArea offset="0 0.5 0.15" width="2.35" height="2.3" length="7.1"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_marshallBC32/marshallBC32.xml" selectedConfigs="1" modHubId="235656">
-            <loadingArea offset="0 1.35 -0.18" width="2.45" height="2.6" length="9.5" baleHeight="3.8"/>
+            <loadingArea offset="0 1.338 -0.18" width="2.45" height="2.6" length="9.5" baleHeight="3.8"/>
             <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_marshallBC32/marshallBC32.xml" selectedConfigs="2" modHubId="235656">
-            <loadingArea offset="0 1.35 -0.18" width="2.45" height="2.6" length="9.5" baleHeight="3.8"/>
+            <loadingArea offset="0 1.338 -0.04" width="2.45" height="2.6" length="9.25" baleHeight="3.8"/>
             <options isBaleTrailer="true" enableSideLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_JunkkariJ16_J18/j16jl.xml" selectedConfigs="1" modHubId="249628">
-            <loadingArea offset="0 0.854 -0.93" width="2.65" height="2.6" length="6.3" baleHeight="3.8"/>
+            <loadingArea offset="0 0.854 -0.72" width="2.65" height="2.6" length="5.8" baleHeight="3.8"/>
             <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_JunkkariJ16_J18/j16jl.xml" selectedConfigs="2" modHubId="249628">
             <loadingArea offset="0 0.854 -1.35" width="2.53" height="2.6" length="7.4" baleHeight="3.8"/>
             <options isBaleTrailer="true" enableSideLoading="true"/>
         </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_JunkkariJ16_J18/j16jl.xml" selectedConfigs="3" modHubId="249628">
-            <loadingArea offset="0 0.854 -0.72" width="2.65" height="2.6" length="5.8" baleHeight="3.8" noLoadingIfFolded="true"/>
-            <options isBaleTrailer="true" enableSideLoading="true"/>
-        </vehicleConfiguration>
-        <vehicleConfiguration configFileName="FS22_Old20FootBaleTrailer/baleTrailer20Foot.xml" modHubId="267221">
-            <loadingArea offset="0 1.084 -0.1" width="2.65" height="2.6" length="6.5" baleHeight="3.8"/>
+        <vehicleConfiguration configFileName="FS22_Old20FootBaleTrailer/baleTrailer20Foot.xml" useConfigName="vehicleType" selectedConfigs="1" modHubId="267221">
+            <loadingArea offset="0 1.084 -0.1" width="2.65" height="2.6" length="6.35" baleHeight="3.8"/>
             <options isBaleTrailer="true" enableSideLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_manTGX_26640_strawbale/tgx26640.xml" modHubId="264434">

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -557,7 +557,7 @@
 			<options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_LizardLT679SmallLogTrailer/SmallLogTrailer.xml" modHubId="245565">  
-            <loadingArea offset="0 1.35 0.75" width="2.85" height="2.10" length="6.0"/>
+            <loadingArea offset="0 1.35 0.57" width="2.85" height="2.10" length="6.3"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="FS22_LizardLT689LogTrailer/lizardLT689.xml" modHubId="245566">  

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -1042,5 +1042,9 @@
             <loadingArea offset="0 0.897 -1.08" width="2.5" height="2.6" length="7.8" baleHeight="3.8"/>
             <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_camara_rp03/rp03.xml" modHubId="264435">
+            <loadingArea offset="0 0.897 -1.08" width="2.5" height="2.6" length="7.8" baleHeight="3.8"/>
+            <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -988,5 +988,13 @@
             <loadingArea offset="0 2.62 0.35" width="2.35" height="1.4" length="6.5"/>
             <options isLogTrailer="true"/>
         </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_Forest_Platform/Aufbau.xml" modHubId="261023">
+            <loadingArea offset="0 1.84 -1.55" width="2.25" height="2.55" length="6.5"/>
+            <options isLogTrailer="true"/>
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="FS22_Forest_Platform/Aufbau2.xml" modHubId="261023">
+            <loadingArea offset="0 1.84 -1.55" width="2.25" height="2.55" length="6.5"/>
+            <options isLogTrailer="true"/>
+        </vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 240 Configutations  
+#116 Supported Modhub Mods and 243 Configutations  
 
 ## Potato Technology 
 
@@ -142,6 +142,9 @@ Title | Author | Loading Areas | Options Set
 [American Flatbed Pack](https://www.farming-simulator.com/mod.php?mod_id=264240&title=fs2022) | GamerDesigns | 1 | Log Trailer
 [ITRTwo](https://www.farming-simulator.com/mod.php?mod_id=259967&title=fs2022) | Vanquish081 VSR Modding Sur] | 1 | Rear Loading, Side Loading, Bale Trailer
 [ITRTwo](https://www.farming-simulator.com/mod.php?mod_id=259967&title=fs2022) | Vanquish081 VSR Modding Sur] | 1 | Log Trailer
+[Junkkari J16-J18](https://www.farming-simulator.com/mod.php?mod_id=249628&title=fs2022) | Farmari99] | 1 | Rear Loading, Side Loading, Bale Trailer
+[Junkkari J16-J18](https://www.farming-simulator.com/mod.php?mod_id=249628&title=fs2022) | Farmari99] | 1 | Side Loading, Bale Trailer
+[Junkkari J16-J18](https://www.farming-simulator.com/mod.php?mod_id=249628&title=fs2022) | Farmari99] | 1 | Side Loading, Bale Trailer
 ## Low Loaders 
 
 Title | Author | Loading Areas | Options Set

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 238 Configutations  
+#116 Supported Modhub Mods and 240 Configutations  
 
 ## Potato Technology 
 
@@ -238,6 +238,8 @@ Title | Author | Loading Areas | Options Set
 [Homemade Bale Trailer](https://www.farming-simulator.com/mod.php?mod_id=256429&title=fs2022) | Slajmon | 1 | Side Loading, Bale Trailer
 [Rolland RP LCH Trailers](https://www.farming-simulator.com/mod.php?mod_id=240058&title=fs2022) | ARM-Team | 1 | Side Loading, Bale Trailer
 [Rolland RP LCH Trailers](https://www.farming-simulator.com/mod.php?mod_id=240058&title=fs2022) | ARM-Team | 1 | Side Loading, Bale Trailer
+[Marshall BC/32](https://www.farming-simulator.com/mod.php?mod_id=235656&title=fs2022) | E.T.A La Marchoise | 1 | Side Loading, Rear Loading, Bale Trailer
+[Marshall BC/32](https://www.farming-simulator.com/mod.php?mod_id=235656&title=fs2022) | E.T.A La Marchoise | 1 | Side Loading, Bale Trailer
 ## Trucks 
 
 Title | Author | Loading Areas | Options Set

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 245 Configutations  
+#116 Supported Modhub Mods and 246 Configutations  
 
 ## Potato Technology 
 
@@ -145,6 +145,7 @@ Title | Author | Loading Areas | Options Set
 [Junkkari J16-J18](https://www.farming-simulator.com/mod.php?mod_id=249628&title=fs2022) | Farmari99] | 1 | Rear Loading, Side Loading, Bale Trailer
 [Junkkari J16-J18](https://www.farming-simulator.com/mod.php?mod_id=249628&title=fs2022) | Farmari99] | 1 | Side Loading, Bale Trailer
 [Junkkari J16-J18](https://www.farming-simulator.com/mod.php?mod_id=249628&title=fs2022) | Farmari99] | 1 | Side Loading, Bale Trailer
+[Lizard Straw Bale Trailer](https://www.farming-simulator.com/mod.php?mod_id=264436&title=fs2022) | caleruega modding design | 1 | Bale Trailer, Rear Loading, Side Loading
 ## Low Loaders 
 
 Title | Author | Loading Areas | Options Set

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 244 Configutations  
+#116 Supported Modhub Mods and 245 Configutations  
 
 ## Potato Technology 
 
@@ -279,6 +279,7 @@ Title | Author | Loading Areas | Options Set
 [FS22_LizardF600](https://www.farming-simulator.com/mod.php?mod_id=243774&title=fs2022) | Farm Centro Sul/FHZ/Cola Modding | 1 | Rear Loading, Side Loading, Bale Trailer
 [FS22_LizardF600](https://www.farming-simulator.com/mod.php?mod_id=243774&title=fs2022) | Farm Centro Sul/FHZ/Cola Modding | 1 | Rear Loading, Side Loading
 [FS22_LizardF600](https://www.farming-simulator.com/mod.php?mod_id=243774&title=fs2022) | Farm Centro Sul/FHZ/Cola Modding | 1 | Log Trailer
+[MAN TGX 26.640 Straw Bale](https://www.farming-simulator.com/mod.php?mod_id=264434&title=fs2022) | caleruega modding design | 1 | Bale Trailer, Rear Loading, Side Loading
 ## Forestry Equipment 
 
 Title | Author | Loading Areas | Options Set

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 243 Configutations  
+#116 Supported Modhub Mods and 244 Configutations  
 
 ## Potato Technology 
 
@@ -243,6 +243,7 @@ Title | Author | Loading Areas | Options Set
 [Rolland RP LCH Trailers](https://www.farming-simulator.com/mod.php?mod_id=240058&title=fs2022) | ARM-Team | 1 | Side Loading, Bale Trailer
 [Marshall BC/32](https://www.farming-simulator.com/mod.php?mod_id=235656&title=fs2022) | E.T.A La Marchoise | 1 | Side Loading, Rear Loading, Bale Trailer
 [Marshall BC/32](https://www.farming-simulator.com/mod.php?mod_id=235656&title=fs2022) | E.T.A La Marchoise | 1 | Side Loading, Bale Trailer
+[20 Foot Bale Trailer](https://www.farming-simulator.com/mod.php?mod_id=267221&title=fs2022) | 4D Modding Eire Agri Modding | 1 | Side Loading, Bale Trailer
 ## Trucks 
 
 Title | Author | Loading Areas | Options Set

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 231 Configutations  
+#116 Supported Modhub Mods and 234 Configutations  
 
 ## Potato Technology 
 
@@ -267,6 +267,9 @@ Title | Author | Loading Areas | Options Set
 [AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Rear Loading, Side Loading, Bale Trailer
 [AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Log Trailer
 [AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Log Trailer
+[FS22_LizardF600](https://www.farming-simulator.com/mod.php?mod_id=243774&title=fs2022) | Farm Centro Sul/FHZ/Cola Modding | 1 | Rear Loading, Side Loading, Bale Trailer
+[FS22_LizardF600](https://www.farming-simulator.com/mod.php?mod_id=243774&title=fs2022) | Farm Centro Sul/FHZ/Cola Modding | 1 | Rear Loading, Side Loading
+[FS22_LizardF600](https://www.farming-simulator.com/mod.php?mod_id=243774&title=fs2022) | Farm Centro Sul/FHZ/Cola Modding | 1 | Log Trailer
 ## Forestry Equipment 
 
 Title | Author | Loading Areas | Options Set

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 237 Configutations  
+#116 Supported Modhub Mods and 238 Configutations  
 
 ## Potato Technology 
 
@@ -216,6 +216,7 @@ Title | Author | Loading Areas | Options Set
 Title | Author | Loading Areas | Options Set
 ---|---|:---:|---
 [Bailey Bale And Pallet Trailer](https://www.farming-simulator.com/mod.php?mod_id=228030&title=fs2022) | Bolex Simulation | 1 | Side Loading, Bale Trailer
+[Bailey Bale And Pallet Trailer](https://www.farming-simulator.com/mod.php?mod_id=228030&title=fs2022) | Bolex Simulation | 1 | Side Loading, Rear Loading, Bale Trailer
 [DPW1800](https://www.farming-simulator.com/mod.php?mod_id=231490&title=fs2022) | Keilermodding | 2 | Side Loading, Bale Trailer
 [Fliegl DPW 180](https://www.farming-simulator.com/mod.php?mod_id=224967&title=fs2022) | Hydraulik | 1 | Side Loading, Bale Trailer
 [Fliegl DPW Pack](https://www.farming-simulator.com/mod.php?mod_id=225492&title=fs2022) | MefiuFs | 1 | Side Loading, Bale Trailer

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#128 Supported Modhub Mods and 247 Configutations  
+#116 Supported Modhub Mods and 219 Configutations  
 
 ## Potato Technology 
 
@@ -136,24 +136,13 @@ Title | Author | Loading Areas | Options Set
 [Small Flatbed Autoload Trailer](https://www.farming-simulator.com/mod.php?mod_id=247924&title=fs2022) | macktrucker921 | 1 | Log Trailer
 [Lizard GVW J4027](https://www.farming-simulator.com/mod.php?mod_id=260582&title=fs2022) | Hydraulik | 1 | Rear Loading, Side Loading
 [Metaltech DBL Pack](https://www.farming-simulator.com/mod.php?mod_id=258412&title=fs2022) | Matt26 | 1 | Side Loading
-[American Flatbed Pack](https://www.farming-simulator.com/mod.php?mod_id=264240&title=fs2022) | GamerDesigns | 1 | Side Loading
-[American Flatbed Pack](https://www.farming-simulator.com/mod.php?mod_id=264240&title=fs2022) | GamerDesigns | 1 | Log Trailer
-[American Flatbed Pack](https://www.farming-simulator.com/mod.php?mod_id=264240&title=fs2022) | GamerDesigns | 1 | Side Loading
-[American Flatbed Pack](https://www.farming-simulator.com/mod.php?mod_id=264240&title=fs2022) | GamerDesigns | 1 | Log Trailer
-[ITRTwo](https://www.farming-simulator.com/mod.php?mod_id=259967&title=fs2022) | Vanquish081 VSR Modding Sur] | 1 | Rear Loading, Side Loading, Bale Trailer
-[ITRTwo](https://www.farming-simulator.com/mod.php?mod_id=259967&title=fs2022) | Vanquish081 VSR Modding Sur] | 1 | Log Trailer
-[Junkkari J16-J18](https://www.farming-simulator.com/mod.php?mod_id=249628&title=fs2022) | Farmari99] | 1 | Rear Loading, Side Loading, Bale Trailer
-[Junkkari J16-J18](https://www.farming-simulator.com/mod.php?mod_id=249628&title=fs2022) | Farmari99] | 1 | Side Loading, Bale Trailer
-[Junkkari J16-J18](https://www.farming-simulator.com/mod.php?mod_id=249628&title=fs2022) | Farmari99] | 1 | Side Loading, Bale Trailer
-[Lizard Straw Bale Trailer](https://www.farming-simulator.com/mod.php?mod_id=264436&title=fs2022) | caleruega modding design | 1 | Bale Trailer, Rear Loading, Side Loading
-[Camara Straw Bale Trailer](https://www.farming-simulator.com/mod.php?mod_id=264435&title=fs2022) | caleruega modding design | 1 | Bale Trailer, Rear Loading, Side Loading
 ## Low Loaders 
 
 Title | Author | Loading Areas | Options Set
 ---|---|:---:|---
 [Fliegl SDS350J](https://www.farming-simulator.com/mod.php?mod_id=226313&title=fs2022) | Peppe978 | 3 | Rear Loading, Side Loading
 [Lizard Self-Made Trailer](https://www.farming-simulator.com/mod.php?mod_id=229132&title=fs2022) | KaWa | 1 | Rear Loading
-[Straw Bale Semitrailer](https://www.farming-simulator.com/mod.php?mod_id=243958&title=fs2022) | caleruega modding design | 1 | Bale Trailer, Rear Loading, Side Loading
+[Straw Bale Semitrailer](https://www.farming-simulator.com/mod.php?mod_id=243958&title=fs2022) | caleruega modding design | 1 | Rear Loading, Side Loading
 [Transport Platform 4000/H](https://www.farming-simulator.com/mod.php?mod_id=232175&title=fs2022) | Adub Modding ABP Team Feat.BSM | 1 | Rear Loading, Side Loading
 [Transport Platform 4000/H](https://www.farming-simulator.com/mod.php?mod_id=232175&title=fs2022) | Adub Modding ABP Team Feat.BSM | 1 | Rear Loading, Side Loading
 [McCauley Lowloader](https://www.farming-simulator.com/mod.php?mod_id=252504&title=fs2022) | FastFarming | 2 | Side Loading
@@ -221,7 +210,6 @@ Title | Author | Loading Areas | Options Set
 Title | Author | Loading Areas | Options Set
 ---|---|:---:|---
 [Bailey Bale And Pallet Trailer](https://www.farming-simulator.com/mod.php?mod_id=228030&title=fs2022) | Bolex Simulation | 1 | Side Loading, Bale Trailer
-[Bailey Bale And Pallet Trailer](https://www.farming-simulator.com/mod.php?mod_id=228030&title=fs2022) | Bolex Simulation | 1 | Side Loading, Rear Loading, Bale Trailer
 [DPW1800](https://www.farming-simulator.com/mod.php?mod_id=231490&title=fs2022) | Keilermodding | 2 | Side Loading, Bale Trailer
 [Fliegl DPW 180](https://www.farming-simulator.com/mod.php?mod_id=224967&title=fs2022) | Hydraulik | 1 | Side Loading, Bale Trailer
 [Fliegl DPW Pack](https://www.farming-simulator.com/mod.php?mod_id=225492&title=fs2022) | MefiuFs | 1 | Side Loading, Bale Trailer
@@ -233,7 +221,7 @@ Title | Author | Loading Areas | Options Set
 [Lizard Flatbed Trailer](https://www.farming-simulator.com/mod.php?mod_id=241140&title=fs2022) | North Modding Company | 1 | Rear Loading, Side Loading
 [John Deere 1075 Hay Wagon](https://www.farming-simulator.com/mod.php?mod_id=242834&title=fs2022) | Rooster Mods, 46 Mods | 1 | Side Loading, Bale Trailer
 [Tps-001](https://www.farming-simulator.com/mod.php?mod_id=233090&title=fs2022) | Serega_56 | 1 | Rear Loading, Side Loading
-[Camara Straw Bale Semitrailer](https://www.farming-simulator.com/mod.php?mod_id=243957&title=fs2022) | caleruega modding design | 1 | Bale Trailer, Rear Loading, Side Loading
+[Camara Straw Bale Semitrailer](https://www.farming-simulator.com/mod.php?mod_id=243957&title=fs2022) | caleruega modding design | 1 | Rear Loading, Side Loading
 [Marston 22' Bale Trailer 1993](https://www.farming-simulator.com/mod.php?mod_id=252407&title=fs2022) | johndeere2450, Mattxjs | 1 | Side Loading, Bale Trailer
 [Lizard Bale Trailer](https://www.farming-simulator.com/mod.php?mod_id=243382&title=fs2022) | TomSky | 1 | Side Loading
 [Multi Trailer Pack](https://www.farming-simulator.com/mod.php?mod_id=247532&title=fs2022) | WOLFex Modding | 1 | Rear Loading, Side Loading
@@ -241,11 +229,6 @@ Title | Author | Loading Areas | Options Set
 [Multi Trailer Pack](https://www.farming-simulator.com/mod.php?mod_id=247532&title=fs2022) | WOLFex Modding | 1 | Rear Loading, Side Loading
 [Multi Trailer Pack](https://www.farming-simulator.com/mod.php?mod_id=247532&title=fs2022) | WOLFex Modding | 1 | Log Trailer
 [Homemade Bale Trailer](https://www.farming-simulator.com/mod.php?mod_id=256429&title=fs2022) | Slajmon | 1 | Side Loading, Bale Trailer
-[Rolland RP LCH Trailers](https://www.farming-simulator.com/mod.php?mod_id=240058&title=fs2022) | ARM-Team | 1 | Side Loading, Bale Trailer
-[Rolland RP LCH Trailers](https://www.farming-simulator.com/mod.php?mod_id=240058&title=fs2022) | ARM-Team | 1 | Side Loading, Bale Trailer
-[Marshall BC/32](https://www.farming-simulator.com/mod.php?mod_id=235656&title=fs2022) | E.T.A La Marchoise | 1 | Side Loading, Rear Loading, Bale Trailer
-[Marshall BC/32](https://www.farming-simulator.com/mod.php?mod_id=235656&title=fs2022) | E.T.A La Marchoise | 1 | Side Loading, Bale Trailer
-[20 Foot Bale Trailer](https://www.farming-simulator.com/mod.php?mod_id=267221&title=fs2022) | 4D Modding Eire Agri Modding | 1 | Side Loading, Bale Trailer
 ## Trucks 
 
 Title | Author | Loading Areas | Options Set
@@ -272,16 +255,6 @@ Title | Author | Loading Areas | Options Set
 [MAN TGX 26640 Box Pack](https://www.farming-simulator.com/mod.php?mod_id=262385&title=fs2022) | By TB.Simulationen | 1 | Rear Loading, Side Loading, Bale Trailer, Box Trailer
 [MAN TGX 26640 Box Pack](https://www.farming-simulator.com/mod.php?mod_id=262385&title=fs2022) | By TB.Simulationen | 1 | Rear Loading, Side Loading, Bale Trailer, Box Trailer
 [MAN TGX 26640 Box Pack](https://www.farming-simulator.com/mod.php?mod_id=262385&title=fs2022) | By TB.Simulationen | 1 | Rear Loading, Side Loading, Bale Trailer, Box Trailer
-[AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Rear Loading, Box Trailer
-[AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Rear Loading, Box Trailer
-[AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Rear Loading, Side Loading, Bale Trailer
-[AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Rear Loading, Side Loading, Bale Trailer
-[AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Log Trailer
-[AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Log Trailer
-[FS22_LizardF600](https://www.farming-simulator.com/mod.php?mod_id=243774&title=fs2022) | Farm Centro Sul/FHZ/Cola Modding | 1 | Rear Loading, Side Loading, Bale Trailer
-[FS22_LizardF600](https://www.farming-simulator.com/mod.php?mod_id=243774&title=fs2022) | Farm Centro Sul/FHZ/Cola Modding | 1 | Rear Loading, Side Loading
-[FS22_LizardF600](https://www.farming-simulator.com/mod.php?mod_id=243774&title=fs2022) | Farm Centro Sul/FHZ/Cola Modding | 1 | Log Trailer
-[MAN TGX 26.640 Straw Bale](https://www.farming-simulator.com/mod.php?mod_id=264434&title=fs2022) | caleruega modding design | 1 | Bale Trailer, Rear Loading, Side Loading
 ## Forestry Equipment 
 
 Title | Author | Loading Areas | Options Set
@@ -314,4 +287,5 @@ Title | Author | Loading Areas | Options Set
 [Komatsu Forwarder Pack](https://www.farming-simulator.com/mod.php?mod_id=247034&title=fs2022) | HR Forst und Fahrzeugbau | 2 | Log Trailer
 [Logger](https://www.farming-simulator.com/mod.php?mod_id=230269&title=fs2022) | Farm Sim World, FS Modding | 1 | Log Trailer
 [Plantation Trailer](https://www.farming-simulator.com/mod.php?mod_id=242524&title=fs2022) | GamerDesigns | 1 | Log Trailer
-[Befa Shortwood Swap Body Pack](https://www.farming-simulator.com/mod.php?mod_id=261023&title=fs2022) | HR Forst und Fahrzeugbau | 1 | Log Trailer
+
+

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -151,7 +151,7 @@ Title | Author | Loading Areas | Options Set
 ---|---|:---:|---
 [Fliegl SDS350J](https://www.farming-simulator.com/mod.php?mod_id=226313&title=fs2022) | Peppe978 | 3 | Rear Loading, Side Loading
 [Lizard Self-Made Trailer](https://www.farming-simulator.com/mod.php?mod_id=229132&title=fs2022) | KaWa | 1 | Rear Loading
-[Straw Bale Semitrailer](https://www.farming-simulator.com/mod.php?mod_id=243958&title=fs2022) | caleruega modding design | 1 | Rear Loading, Side Loading
+[Straw Bale Semitrailer](https://www.farming-simulator.com/mod.php?mod_id=243958&title=fs2022) | caleruega modding design | 1 | Bale Trailer, Rear Loading, Side Loading
 [Transport Platform 4000/H](https://www.farming-simulator.com/mod.php?mod_id=232175&title=fs2022) | Adub Modding ABP Team Feat.BSM | 1 | Rear Loading, Side Loading
 [Transport Platform 4000/H](https://www.farming-simulator.com/mod.php?mod_id=232175&title=fs2022) | Adub Modding ABP Team Feat.BSM | 1 | Rear Loading, Side Loading
 [McCauley Lowloader](https://www.farming-simulator.com/mod.php?mod_id=252504&title=fs2022) | FastFarming | 2 | Side Loading

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -231,7 +231,7 @@ Title | Author | Loading Areas | Options Set
 [Lizard Flatbed Trailer](https://www.farming-simulator.com/mod.php?mod_id=241140&title=fs2022) | North Modding Company | 1 | Rear Loading, Side Loading
 [John Deere 1075 Hay Wagon](https://www.farming-simulator.com/mod.php?mod_id=242834&title=fs2022) | Rooster Mods, 46 Mods | 1 | Side Loading, Bale Trailer
 [Tps-001](https://www.farming-simulator.com/mod.php?mod_id=233090&title=fs2022) | Serega_56 | 1 | Rear Loading, Side Loading
-[Camara Straw Bale Semitrailer](https://www.farming-simulator.com/mod.php?mod_id=243957&title=fs2022) | caleruega modding design | 1 | Rear Loading, Side Loading
+[Camara Straw Bale Semitrailer](https://www.farming-simulator.com/mod.php?mod_id=243957&title=fs2022) | caleruega modding design | 1 | Bale Trailer, Rear Loading, Side Loading
 [Marston 22' Bale Trailer 1993](https://www.farming-simulator.com/mod.php?mod_id=252407&title=fs2022) | johndeere2450, Mattxjs | 1 | Side Loading, Bale Trailer
 [Lizard Bale Trailer](https://www.farming-simulator.com/mod.php?mod_id=243382&title=fs2022) | TomSky | 1 | Side Loading
 [Multi Trailer Pack](https://www.farming-simulator.com/mod.php?mod_id=247532&title=fs2022) | WOLFex Modding | 1 | Rear Loading, Side Loading

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 223 Configutations  
+#116 Supported Modhub Mods and 225 Configutations  
 
 ## Potato Technology 
 
@@ -233,6 +233,8 @@ Title | Author | Loading Areas | Options Set
 [Multi Trailer Pack](https://www.farming-simulator.com/mod.php?mod_id=247532&title=fs2022) | WOLFex Modding | 1 | Rear Loading, Side Loading
 [Multi Trailer Pack](https://www.farming-simulator.com/mod.php?mod_id=247532&title=fs2022) | WOLFex Modding | 1 | Log Trailer
 [Homemade Bale Trailer](https://www.farming-simulator.com/mod.php?mod_id=256429&title=fs2022) | Slajmon | 1 | Side Loading, Bale Trailer
+[Rolland RP LCH Trailers](https://www.farming-simulator.com/mod.php?mod_id=240058&title=fs2022) | ARM-Team | 1 | Side Loading, Bale Trailer
+[Rolland RP LCH Trailers](https://www.farming-simulator.com/mod.php?mod_id=240058&title=fs2022) | ARM-Team | 1 | Side Loading, Bale Trailer
 ## Trucks 
 
 Title | Author | Loading Areas | Options Set

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 246 Configutations  
+#116 Supported Modhub Mods and 247 Configutations  
 
 ## Potato Technology 
 
@@ -146,6 +146,7 @@ Title | Author | Loading Areas | Options Set
 [Junkkari J16-J18](https://www.farming-simulator.com/mod.php?mod_id=249628&title=fs2022) | Farmari99] | 1 | Side Loading, Bale Trailer
 [Junkkari J16-J18](https://www.farming-simulator.com/mod.php?mod_id=249628&title=fs2022) | Farmari99] | 1 | Side Loading, Bale Trailer
 [Lizard Straw Bale Trailer](https://www.farming-simulator.com/mod.php?mod_id=264436&title=fs2022) | caleruega modding design | 1 | Bale Trailer, Rear Loading, Side Loading
+[Camara Straw Bale Trailer](https://www.farming-simulator.com/mod.php?mod_id=264435&title=fs2022) | caleruega modding design | 1 | Bale Trailer, Rear Loading, Side Loading
 ## Low Loaders 
 
 Title | Author | Loading Areas | Options Set

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 235 Configutations  
+#116 Supported Modhub Mods and 237 Configutations  
 
 ## Potato Technology 
 
@@ -140,6 +140,8 @@ Title | Author | Loading Areas | Options Set
 [American Flatbed Pack](https://www.farming-simulator.com/mod.php?mod_id=264240&title=fs2022) | GamerDesigns | 1 | Log Trailer
 [American Flatbed Pack](https://www.farming-simulator.com/mod.php?mod_id=264240&title=fs2022) | GamerDesigns | 1 | Side Loading
 [American Flatbed Pack](https://www.farming-simulator.com/mod.php?mod_id=264240&title=fs2022) | GamerDesigns | 1 | Log Trailer
+[ITRTwo](https://www.farming-simulator.com/mod.php?mod_id=259967&title=fs2022) | Vanquish081 VSR Modding Sur] | 1 | Rear Loading, Side Loading, Bale Trailer
+[ITRTwo](https://www.farming-simulator.com/mod.php?mod_id=259967&title=fs2022) | Vanquish081 VSR Modding Sur] | 1 | Log Trailer
 ## Low Loaders 
 
 Title | Author | Loading Areas | Options Set

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 234 Configutations  
+#116 Supported Modhub Mods and 235 Configutations  
 
 ## Potato Technology 
 
@@ -302,5 +302,4 @@ Title | Author | Loading Areas | Options Set
 [Komatsu Forwarder Pack](https://www.farming-simulator.com/mod.php?mod_id=247034&title=fs2022) | HR Forst und Fahrzeugbau | 2 | Log Trailer
 [Logger](https://www.farming-simulator.com/mod.php?mod_id=230269&title=fs2022) | Farm Sim World, FS Modding | 1 | Log Trailer
 [Plantation Trailer](https://www.farming-simulator.com/mod.php?mod_id=242524&title=fs2022) | GamerDesigns | 1 | Log Trailer
-
-
+[Befa Shortwood Swap Body Pack](https://www.farming-simulator.com/mod.php?mod_id=261023&title=fs2022) | HR Forst und Fahrzeugbau | 1 | Log Trailer

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 225 Configutations  
+#116 Supported Modhub Mods and 231 Configutations  
 
 ## Potato Technology 
 
@@ -261,6 +261,12 @@ Title | Author | Loading Areas | Options Set
 [MAN TGX 26640 Box Pack](https://www.farming-simulator.com/mod.php?mod_id=262385&title=fs2022) | By TB.Simulationen | 1 | Rear Loading, Side Loading, Bale Trailer, Box Trailer
 [MAN TGX 26640 Box Pack](https://www.farming-simulator.com/mod.php?mod_id=262385&title=fs2022) | By TB.Simulationen | 1 | Rear Loading, Side Loading, Bale Trailer, Box Trailer
 [MAN TGX 26640 Box Pack](https://www.farming-simulator.com/mod.php?mod_id=262385&title=fs2022) | By TB.Simulationen | 1 | Rear Loading, Side Loading, Bale Trailer, Box Trailer
+[AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Rear Loading, Box Trailer
+[AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Rear Loading, Box Trailer
+[AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Rear Loading, Side Loading, Bale Trailer
+[AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Rear Loading, Side Loading, Bale Trailer
+[AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Log Trailer
+[AW 362 Rigged](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022) | Adams Kong | 1 | Log Trailer
 ## Forestry Equipment 
 
 Title | Author | Loading Areas | Options Set

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 219 Configutations  
+#116 Supported Modhub Mods and 223 Configutations  
 
 ## Potato Technology 
 
@@ -136,6 +136,10 @@ Title | Author | Loading Areas | Options Set
 [Small Flatbed Autoload Trailer](https://www.farming-simulator.com/mod.php?mod_id=247924&title=fs2022) | macktrucker921 | 1 | Log Trailer
 [Lizard GVW J4027](https://www.farming-simulator.com/mod.php?mod_id=260582&title=fs2022) | Hydraulik | 1 | Rear Loading, Side Loading
 [Metaltech DBL Pack](https://www.farming-simulator.com/mod.php?mod_id=258412&title=fs2022) | Matt26 | 1 | Side Loading
+[American Flatbed Pack](https://www.farming-simulator.com/mod.php?mod_id=264240&title=fs2022) | GamerDesigns | 1 | Side Loading
+[American Flatbed Pack](https://www.farming-simulator.com/mod.php?mod_id=264240&title=fs2022) | GamerDesigns | 1 | Log Trailer
+[American Flatbed Pack](https://www.farming-simulator.com/mod.php?mod_id=264240&title=fs2022) | GamerDesigns | 1 | Side Loading
+[American Flatbed Pack](https://www.farming-simulator.com/mod.php?mod_id=264240&title=fs2022) | GamerDesigns | 1 | Log Trailer
 ## Low Loaders 
 
 Title | Author | Loading Areas | Options Set

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -1,4 +1,4 @@
-#116 Supported Modhub Mods and 247 Configutations  
+#128 Supported Modhub Mods and 247 Configutations  
 
 ## Potato Technology 
 


### PR DESCRIPTION
Added support for:
- [FS22_AmericanFlatbedPack](https://www.farming-simulator.com/mod.php?mod_id=264240&title=fs2022)
- [FS22_RollandRPLCH](https://www.farming-simulator.com/mod.php?mod_id=240058&title=fs2022)
- [FS22_AW362_CaboverR](https://www.farming-simulator.com/mod.php?mod_id=250565&title=fs2022)
- [FS22_LizardF600](https://www.farming-simulator.com/mod.php?mod_id=243774&title=fs2022)

Fixes for:
- [FS22_LizardLT679SmallLogTrailer](https://www.farming-simulator.com/mod.php?mod_id=245565&title=fs2022)
- [FS22_Komatsu_Forwarder_Pack](https://www.farming-simulator.com/mod.php?mod_id=247034&title=fs2022)

Everything tested with various sizes of palets, bales and wood logs.
In testing used only FS22_UniversalAutoload v.1.3.3.0 and FS22_EasyDevControls v.1.3.0.2