### PR TITLE
Add support for Lenormand 12m Trailer

### DIFF
--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -928,5 +928,9 @@
             <loadingArea offset="0.000 1.11 -1.65" width="2.0" height="1.75" length="3.0" baleHeight="2.75"/>
             <options enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_Lenormand_12m/Lenormand.xml" modHubId="270383">
+            <loadingArea offset="0 1.096 -1.51" width="2.55" height="1.90" length="12.05" baleHeight="3.7"/>
+            <options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
+        </vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>

--- a/supportedMods.md
+++ b/supportedMods.md
@@ -136,6 +136,7 @@ Title | Author | Loading Areas | Options Set
 [Small Flatbed Autoload Trailer](https://www.farming-simulator.com/mod.php?mod_id=247924&title=fs2022) | macktrucker921 | 1 | Log Trailer
 [Lizard GVW J4027](https://www.farming-simulator.com/mod.php?mod_id=260582&title=fs2022) | Hydraulik | 1 | Rear Loading, Side Loading
 [Metaltech DBL Pack](https://www.farming-simulator.com/mod.php?mod_id=258412&title=fs2022) | Matt26 | 1 | Side Loading
+[Lenormand 12m] (https://www.farming-simulator.com/mod.php?mod_id=270383&title=fs2022)	| AgriDesignModding | 1 | Side Loading
 ## Low Loaders 
 
 Title | Author | Loading Areas | Options Set


### PR DESCRIPTION
Hi,
Here the support for the Lenormand 12m trailer.
[https://www.farming-simulator.com/mod.php?lang=fr&country=fr&mod_id=270383&title=fs2022](https://www.farming-simulator.com/mod.php?lang=fr&country=fr&mod_id=270383&title=fs2022)
With the courtesy of AgriDesignModding who has tested this with success. In case you need to contact him : nicodu55.fs@gmail.com