### PR TITLE
Support for FS22_Lenormand_12m

### DIFF
--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -1063,12 +1063,12 @@
 			<options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
 		</vehicleConfiguration>
 		<vehicleConfiguration configFileName="FS22_Lenormand_12m/Lenormand.xml" selectedConfigs="1" modHubId="270383">
-			<loadingArea offset="0 1.096 -1.51" width="2.55" height="2.6" length="12.05" baleHeight="3.7"/>
+			<loadingArea offset="0 1.096 -1.51" width="2.55" height="2.6" length="12.02" baleHeight="3.6"/>
 			<options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
 		</vehicleConfiguration>
 		<vehicleConfiguration configFileName="FS22_Lenormand_12m/Lenormand.xml" selectedConfigs="2" modHubId="270383">
-			<loadingArea offset="0 1.096 -1.51" width="2.55" height="2.6" length="12.05" baleHeight="3.7" noLoadingIfUnfolded="true"/>
-			<loadingArea offset="0 1.096 -1.51" width="2.55" height="2.6" length="15.05" baleHeight="3.7" noLoadingIfFolded="true"/>
+			<loadingArea offset="0 1.096 -1.51" width="2.55" height="2.6" length="12.02" baleHeight="3.6" noLoadingIfUnfolded="true"/>
+			<loadingArea offset="0 1.096 -1.74" width="2.55" height="2.6" length="13.02" baleHeight="3.6" noLoadingIfFolded="true"/>
 			<options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
 		</vehicleConfiguration>
 	</vehicleConfigurations>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -934,19 +934,19 @@
 			<loadingArea offset="0 1.11 -1.65" width="2" height="1.75" length="3" baleHeight="2.75"/>
 			<options enableRearLoading="true" enableSideLoading="true"/>
 		</vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" useConfigName="design" selectedConfigs="1" modHubId="264240">
+		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" selectedConfigs="1" modHubId="264240">
 			<loadingArea offset="-0.09 1.49 -0.1" width="2.7" height="2.5" length="12.9" baleHeight="3.8"/>
 			<options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
 		</vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" useConfigName="design" selectedConfigs="2" modHubId="264240">
+		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/flatbed.xml" selectedConfigs="2" modHubId="264240">
 			<loadingArea offset="-0.09 1.49 -0.1" width="2.6" height="2.7" length="12.9"/>
 			<options isLogTrailer="true"/>
 		</vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" useConfigName="design" selectedConfigs="1" modHubId="264240">
+		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" selectedConfigs="1" modHubId="264240">
 			<loadingArea offset="-0.1 1.73 -1.58" width="2.7" height="2.5" length="9.3" baleHeight="3.8"/>
 			<options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
 		</vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" useConfigName="design" selectedConfigs="2" modHubId="264240">
+		<vehicleConfiguration configFileName="FS22_AmericanFlatbedPack/shorty.xml" selectedConfigs="2" modHubId="264240">
 			<loadingArea offset="-0.1 1.73 -1.46" width="2.6" height="2.5" length="9"/>
 			<options isLogTrailer="true"/>
 		</vehicleConfiguration>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -1062,5 +1062,14 @@
 			<loadingArea offset="0 0.933 -0.34" width="2.5" height="2.6" length="8.06" baleHeight="3.6"/>
 			<options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
 		</vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_Lenormand_12m/Lenormand.xml" selectedConfigs="1" modHubId="270383">
+			<loadingArea offset="0 1.096 -1.51" width="2.55" height="2.6" length="12.05" baleHeight="3.7"/>
+			<options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
+		</vehicleConfiguration>
+		<vehicleConfiguration configFileName="FS22_Lenormand_12m/Lenormand.xml" selectedConfigs="2" modHubId="270383">
+			<loadingArea offset="0 1.096 -1.51" width="2.55" height="2.6" length="12.05" baleHeight="3.7" noLoadingIfUnfolded="true"/>
+			<loadingArea offset="0 1.096 -1.51" width="2.55" height="2.6" length="15.05" baleHeight="3.7" noLoadingIfFolded="true"/>
+			<options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
+		</vehicleConfiguration>
 	</vehicleConfigurations>
 </universalAutoLoad>

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -1062,13 +1062,8 @@
 			<loadingArea offset="0 0.933 -0.34" width="2.5" height="2.6" length="8.06" baleHeight="3.6"/>
 			<options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
 		</vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_Lenormand_12m/Lenormand.xml" selectedConfigs="1" modHubId="270383">
+		<vehicleConfiguration configFileName="FS22_Lenormand_12m/Lenormand.xml" modHubId="270383">
 			<loadingArea offset="0 1.096 -1.51" width="2.55" height="2.6" length="12.02" baleHeight="3.6"/>
-			<options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
-		</vehicleConfiguration>
-		<vehicleConfiguration configFileName="FS22_Lenormand_12m/Lenormand.xml" selectedConfigs="2" modHubId="270383">
-			<loadingArea offset="0 1.096 -1.51" width="2.55" height="2.6" length="12.02" baleHeight="3.6" noLoadingIfUnfolded="true"/>
-			<loadingArea offset="0 1.096 -1.74" width="2.55" height="2.6" length="13.02" baleHeight="3.6" noLoadingIfFolded="true"/>
 			<options isBaleTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
 		</vehicleConfiguration>
 	</vehicleConfigurations>


### PR DESCRIPTION
Added support for Lenormand 12m trailer. Implemented also extenders configuration for future mod update by AgriDesignModding.

[FS22_Lenormand_12m](https://www.farming-simulator.com/mod.php?lang=en&country=us&mod_id=270383&title=fs2022)